### PR TITLE
fix some issues

### DIFF
--- a/__tests__/__snapshots__/dedent-tests.js.snap
+++ b/__tests__/__snapshots__/dedent-tests.js.snap
@@ -1,3 +1,14 @@
+exports[`dedent another nested text 1`] = `
+"{
+  int a;
+  struct {
+    int a;
+    int b;
+  } foo;
+  int b;
+}"
+`;
+
 exports[`dedent can be used as a function 1`] = `"A test argument."`;
 
 exports[`dedent doesn't strip exlicit newlines 1`] = `
@@ -13,6 +24,18 @@ exports[`dedent doesn't strip exlicit newlines with mindent 1`] = `
 `;
 
 exports[`dedent escapes backticks 1`] = `"\`"`;
+
+exports[`dedent handles zero indent 1`] = `
+"First line
+  Second line"
+`;
+
+exports[`dedent ignores first line indent 1`] = `
+"{
+  int a;
+  int b;
+}"
+`;
 
 exports[`dedent single line input works with single line and closing backtick on newline 1`] = `"A single line of input."`;
 

--- a/__tests__/dedent-tests.js
+++ b/__tests__/dedent-tests.js
@@ -128,4 +128,31 @@ describe("dedent", () => {
       </p>\n
     `).toMatchSnapshot();
   });
+
+  it("handles zero indent", () => {
+    expect(dd`
+First line
+  Second line
+    `).toMatchSnapshot();
+  });
+
+  it("ignores first line indent", () => {
+    expect(dd`{
+  int a;
+  int b;
+}`).toMatchSnapshot();
+  });
+
+  it("another nested text", () => {
+    const decl = dd`{
+  int a;
+  int b;
+}`;
+    expect(dd`{
+  int a;
+  struct ${decl} foo;
+  int b;
+}`).toMatchSnapshot();
+  });
+
 });

--- a/dedent.js
+++ b/dedent.js
@@ -20,7 +20,7 @@ export default function dedent(
       let value_str: string = String(values[i]);
       // Over-indent multiline interpolations so they don't 'fall' to 0
       if (value_str.includes('\n')) {
-        const spaces_before_match = result.match(/(?:^|\n)( *)$/);
+        const spaces_before_match = result.match(/(?:^|\n)([ \t]*).*$/);
         if (spaces_before_match && typeof value_str === 'string') {
           const spaces_before = spaces_before_match[1];
           result += value_str
@@ -39,11 +39,14 @@ export default function dedent(
   // now strip indentation
   const lines = result.split("\n");
   let mindent: number | null = null;
-  lines.forEach(l => {
-    let m = l.match(/^(\s+)\S+/);
+  lines.forEach((l, index) => {
+    if (!index) {
+      return;
+    }
+    let m = l.match(/^(\s*)\S+/);
     if (m) {
       let indent = m[1].length;
-      if (!mindent) {
+      if (mindent == null) {
         // this is the first indented line
         mindent = indent;
       } else {

--- a/dist/dedent.js
+++ b/dist/dedent.js
@@ -21,7 +21,7 @@ function dedent(strings) {
       var value_str = String(arguments.length <= i + 1 ? undefined : arguments[i + 1]);
       // Over-indent multiline interpolations so they don't 'fall' to 0
       if (value_str.includes('\n')) {
-        var spaces_before_match = result.match(/(?:^|\n)( *)$/);
+        var spaces_before_match = result.match(/(?:^|\n)([ \t]*).*$/);
         if (spaces_before_match && typeof value_str === 'string') {
           (function () {
             var spaces_before = spaces_before_match[1];
@@ -41,11 +41,14 @@ function dedent(strings) {
   // now strip indentation
   var lines = result.split("\n");
   var mindent = null;
-  lines.forEach(function (l) {
-    var m = l.match(/^(\s+)\S+/);
+  lines.forEach(function (l, index) {
+    if (!index) {
+      return;
+    }
+    var m = l.match(/^(\s*)\S+/);
     if (m) {
       var indent = m[1].length;
-      if (!mindent) {
+      if (mindent == null) {
         // this is the first indented line
         mindent = indent;
       } else {


### PR DESCRIPTION
1. Zero intendation is not handled correctly, due to regex and falsy check when calculating minimum indent. Dedent can still be useful in this case due to nested interpolations.
2. First line indentation should be ignored. This issue didn't appear before because zero indentation was ignored.
3. Indentation for nested interpolation only works if they're used at the start of a line - see "another nested test".